### PR TITLE
Fixed: TypeError: Object #<Object> has no method 'connect'

### DIFF
--- a/node-thinkgear.js
+++ b/node-thinkgear.js
@@ -38,7 +38,7 @@ util.inherits(ThinkGearClient, events.EventEmitter);
 ThinkGearClient.prototype.connect = function(){
 	var self = this;
 	
-	var client = this.client = net.connect(this.port,this.host,function(){
+	var client = this.client = net.createConnection(this.port,this.host,function(){
 		client.write(JSON.stringify(self.auth));
 	});
 


### PR DESCRIPTION
Hey I was testing out your code, but it was breaking in the net.connect() method, so I replaced it with net.createConnection() and it worked like a charm.

I'm not very familiar with the net library (or node.js), but hope that can fix it.
