### PR TITLE
Add friendly message if ThinkGear client is not running

### DIFF
--- a/node-neurosky.js
+++ b/node-neurosky.js
@@ -54,6 +54,11 @@ ThinkGearClient.prototype.connect = function(){
 			}
 		}
 	});
+
+    client.on('error', function(err) {
+        console.log('Error connecting to ThinkGear client. Try starting the ThinkGear Connector app.\n', err);
+        process.exit(1);
+    });
 };
 
 exports.ThinkGearClient = ThinkGearClient;


### PR DESCRIPTION
Hi. I thought it would be nice to have a friendly error message if the ThinkGear Connector app isn't running. This may help people trying out your library for the first time.
p.s. Thanks very much - your library was really useful for us!
